### PR TITLE
Fix #86: Reduce verbosity in tutorials

### DIFF
--- a/docs/src/getting-started/tutorials/analytical-primarycensored-cdfs.jl
+++ b/docs/src/getting-started/tutorials/analytical-primarycensored-cdfs.jl
@@ -8,7 +8,6 @@ using InteractiveUtils
 begin
     let
         docs_dir = (dirname ∘ dirname ∘ dirname)(@__DIR__)
-        println(docs_dir)
         using Pkg: Pkg
         Pkg.activate(docs_dir)
         Pkg.instantiate()
@@ -86,7 +85,7 @@ begin
     solver_types = (
         analytical = typeof(pc_gamma_analytical.method),
         numerical = typeof(pc_gamma_numerical.method)
-    )
+    );
 end
 
 # ╔═╡ bbfa05f3-8ae1-4460-b423-b1ccff4ccb62
@@ -166,7 +165,7 @@ benchmark_results = [
     benchmark_cdf_methods(gamma_delay, primary_uniform, "Gamma"),
     benchmark_cdf_methods(lognormal_delay, primary_uniform, "LogNormal"),
     benchmark_cdf_methods(weibull_delay, primary_uniform, "Weibull")
-]
+];
 
 # ╔═╡ b5c22b5c-5d71-4856-a023-1a2740507eca
 # Create performance comparison plots
@@ -284,7 +283,7 @@ begin
         gamma = accuracy_gamma.max_error,
         lognormal = accuracy_lognormal.max_error,
         weibull = accuracy_weibull.max_error
-    )
+    );
 end
 
 # ╔═╡ bc1fae07-e658-46cb-b0f5-80aa07d78d53
@@ -335,7 +334,7 @@ You can use Julia's `methods` function to discover which distribution combinatio
 # ╔═╡ 78a3e849-caae-447f-bc64-4ec24c184fdf
 # Find all analytical CDF implementations
 analytical_methods = methods(CensoredDistributions.primarycensored_cdf,
-    (Any, Any, Real, CensoredDistributions.AnalyticalSolver))
+    (Any, Any, Real, CensoredDistributions.AnalyticalSolver));
 
 # ╔═╡ 523eeb4e-b214-4139-bd02-4b78c83f7648
 md"""
@@ -370,7 +369,7 @@ begin
     solver_info = (
         default = typeof(pc_default.method.solver),
         custom = typeof(pc_custom.method.solver)
-    )
+    );
 end
 
 # ╔═╡ 73ebcbf1-0f7e-45c5-876e-e48d9b7dfd25

--- a/docs/src/getting-started/tutorials/fitting-with-turing.jl
+++ b/docs/src/getting-started/tutorials/fitting-with-turing.jl
@@ -69,31 +69,31 @@ md"### Define the true parameters for generating synthetic data"
 md"We start by defining the number of samples and the true parameters of the lognormal."
 
 # ╔═╡ 28bcd612-19f6-4e25-b6df-cb43df4f2a73
-n = 2000
+n = 2000;
 
 # ╔═╡ 04e414ab-c790-4d31-b216-18776534a287
-meanlog = 1.5
+meanlog = 1.5;
 
 # ╔═╡ 54700ad7-6b2a-440f-903a-c126b4c60c0e
-sdlog = 0.75
+sdlog = 0.75;
 
 # ╔═╡ d3a7196a-185d-445b-afb7-99b546b1f72a
 md"Now we can define a lognormal distribution using Distributions.jl."
 
 # ╔═╡ 7f82b991-00ca-4eed-994a-981c6d66454c
-true_dist = LogNormal(meanlog, sdlog)
+true_dist = LogNormal(meanlog, sdlog);
 
 # ╔═╡ 767a58ed-9d7b-41db-a488-10f98a777474
 md"For each individual we now sample a primary and secondary event window as well as a relative observation time (relative to their censored primary event)."
 
 # ╔═╡ 35472e04-e096-4948-a218-3de53923f271
-pwindows = rand(1:2, n)
+pwindows = rand(1:2, n);
 
 # ╔═╡ 2d0ca6e6-0333-4aec-93d4-43eb9985dc14
-swindows = rand(1:2, n)
+swindows = rand(1:2, n);
 
 # ╔═╡ 6465e51b-8d71-4c85-ba40-e6d230aa53b1
-obs_times = rand(8:12, n)
+obs_times = rand(8:12, n);
 
 # ╔═╡ b5598cc7-ddd1-4d90-af9b-110a518416ac
 md"### Simulate from the double censored distribution for each individual"
@@ -105,7 +105,7 @@ md"Using the `true_dist` and the sampled event times we can sample directly from
 samples = map(pwindows, swindows, obs_times) do pw, sw, ot
     rand(double_interval_censored(
         true_dist; primary_event = Uniform(0.0, pw), upper = ot, interval = sw))
-end
+end;
 
 # ╔═╡ 50757759-9ec3-42d0-a765-df212642885a
 md"Create a dataframe with the data we just generated aggregated to unique combinations and count occurrences.
@@ -130,20 +130,20 @@ Compare the samples with and without secondary censoring to the true distributio
 """
 
 # ╔═╡ 5a6d605d-bff6-4b7d-97f0-ca35750411d3
-empirical_cdf = ecdf(samples)
+empirical_cdf = ecdf(samples);
 
 # ╔═╡ ccd8dd8e-c361-43ba-b4f1-2444ec6008fc
-empirical_cdf_obs = ecdf(delay_counts.observed_delay, weights = delay_counts.n)
+empirical_cdf_obs = ecdf(delay_counts.observed_delay, weights = delay_counts.n);
 
 # ╔═╡ 2b773594-5187-45bc-96f4-22a3d726b7d2
 # Create a sequence of x values for the theoretical CDF
-x_seq = range(minimum(samples), stop = maximum(samples), length = 100)
+x_seq = range(minimum(samples), stop = maximum(samples), length = 100);
 
 # ╔═╡ a5b04acc-acc5-4d4d-8871-09d54caab185
 # Calculate theoretical CDF using true log-normal distribution
 theoretical_cdf = @chain x_seq begin
     cdf.(true_dist, _)
-end
+end;
 
 # ╔═╡ fb6dc898-21a9-4f8d-aa14-5b45974c2242
 let


### PR DESCRIPTION
## Summary

- Suppressed unnecessary output in tutorial notebooks by adding semicolons to parameter assignments and intermediate variables
- Removed debug `println` statement from analytical CDF tutorial
- Preserved all educational content, visualisations, and important results that aid learning
- Maintained tutorial narrative flow and learning objectives

## Changes Made

### fitting-with-turing.jl
- Added semicolons to suppress output from:
  - Parameter assignments (`n`, `meanlog`, `sdlog`)
  - Distribution creation (`true_dist`)
  - Sample generation parameters (`pwindows`, `swindows`, `obs_times`)
  - Data simulation results (`samples`)
  - ECDF calculations and plotting variables
- **Preserved**: Model summaries, plots, and the important `delay_counts` dataframe display

### analytical-primarycensored-cdfs.jl
- Removed debug `println(docs_dir)` statement
- Added semicolons to suppress:
  - Benchmark result storage
  - Solver configuration assignments
  - Method discovery results
- **Preserved**: All performance plots, accuracy results, and educational demonstrations

## Quality Assurance

- ✅ Fast documentation build test passed successfully
- ✅ Code linting and style checks passed (no new issues introduced)
- ✅ Educational content verification confirmed all learning objectives preserved
- ✅ All changes follow project coding standards (80 char limit, no trailing whitespace)

## Acceptance Criteria Met

- ✅ Data simulation parameters no longer display output automatically
- ✅ Sample calls and intermediate computations are suppressed where not educational
- ✅ Educational demonstrations, final results, and visualisations remain visible
- ✅ Tutorial narrative flow and learning objectives preserved
- ✅ Documentation builds successfully without errors

🤖 Generated with [Claude Code](https://claude.ai/code)